### PR TITLE
[IMP] speed up start of container

### DIFF
--- a/src/runboat/kubefiles/deployment.yaml
+++ b/src/runboat/kubefiles/deployment.yaml
@@ -26,6 +26,9 @@ spec:
               mountPath: /runboat
             - name: data
               mountPath: /mnt/data
+            - name: data
+              mountPath: /opt/odoo-venv
+              subPath: odoo-venv
           envFrom:
             - secretRef:
                 name: odoosecretenv

--- a/src/runboat/kubefiles/runboat-clone-and-install.sh
+++ b/src/runboat/kubefiles/runboat-clone-and-install.sh
@@ -5,12 +5,12 @@ set -ex
 
 # If it exists, copy the previously initialized venv.
 if [ -f /mnt/data/initialized ] ; then
-    #rsync -a --delete /mnt/data/odoo-venv/ /opt/odoo-venv
     pip list
-    # issue#23: install debian package dependencies (hack oca_install_addons to only
-    # install deb)
+    # Install 'deb' external dependencies of all Odoo addons found in path.
+    DEBIAN_FRONTEND=noninteractive apt-get install -qq --no-install-recommends $(oca_list_external_dependencies deb)
     exit 0
 fi
+
 DEBIAN_FRONTEND=noninteractive apt-get -yqq install rsync
 
 # Remove addons dir, in case we are reinitializing after a previously

--- a/src/runboat/kubefiles/runboat-clone-and-install.sh
+++ b/src/runboat/kubefiles/runboat-clone-and-install.sh
@@ -2,14 +2,16 @@
 
 set -ex
 
-DEBIAN_FRONTEND=noninteractive apt-get -yq install rsync
 
 # If it exists, copy the previously initialized venv.
 if [ -f /mnt/data/initialized ] ; then
-    rsync -a --delete /mnt/data/odoo-venv/ /opt/odoo-venv
+    #rsync -a --delete /mnt/data/odoo-venv/ /opt/odoo-venv
     pip list
+    # issue#23: install debian package dependencies (hack oca_install_addons to only
+    # install deb)
     exit 0
 fi
+DEBIAN_FRONTEND=noninteractive apt-get -yqq install rsync
 
 # Remove addons dir, in case we are reinitializing after a previously
 # failed installation.


### PR DESCRIPTION
we rsync the virtual env of odoo to a volume at the end of the init
phase. Rather than rsync'ing back, mount the volume on top of the
odoo venv from the base docker image.