### PR TITLE
feat: Set reclaim policy to delete for pvc

### DIFF
--- a/src/runboat/kubefiles/pv.yaml
+++ b/src/runboat/kubefiles/pv.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: runboat-pv-001
+spec:
+  storageClassName: do-block-storage
+  persistentVolumeReclaimPolicy: Delete
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: "/tmp/"

--- a/src/runboat/kubefiles/pvc.yaml
+++ b/src/runboat/kubefiles/pvc.yaml
@@ -1,10 +1,11 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: data
+  name: runboat-pvc-001
 spec:
   accessModes:
     - ReadWriteOnce
+  storageClassName: do-block-storage
   resources:
     requests:
       storage: 200Mi


### PR DESCRIPTION
feat: Set reclaim policy to delete for pvc
After running runboat for quite some time, we have seen a lot of PV (persistent volumes) that are not attached (Released or Available), but the reclaim policy is set to Retain.
This makes the cluster keep a lot of persistent volumes that we don't use, and we can end up hitting the maximum of volumes quite rapidly, since each volumes is 1GB sized.

To fix this issue, we should change the policy to Delete instead, by modifying the pvc.yaml file in runboat.
The whole documentation is available [here](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#reclaim-policy)