### PR TITLE
[FIX] webui-templates: update time-elements library

### DIFF
--- a/src/runboat/webui-templates/runboat-build-element.js
+++ b/src/runboat/webui-templates/runboat-build-element.js
@@ -1,5 +1,5 @@
 import {LitElement, html, css} from 'https://esm.run/lit@2.1.2?module';
-import 'https://esm.run/@github/time-elements@latest?module';
+import 'https://esm.run/@github/relative-time-element@latest?module';
 
 class RunboatBuildElement extends LitElement {
     static get properties() {
@@ -36,9 +36,10 @@ class RunboatBuildElement extends LitElement {
         .build-status-failed {
             background-color: lightcoral;
         }
-        time-ago {
+        relative-time {
             color: gray;
             white-space: nowrap;
+            font-size: small
         }
         p {
             margin-top: 0.5em;
@@ -61,7 +62,7 @@ class RunboatBuildElement extends LitElement {
                 ${this.build.commit_info?.git_commit?
                     html`(<a href="${this.build.repo_commit_link}">${this.build.commit_info?.git_commit.substring(0, 8)}</a>)`:""
                 }
-                <time-ago datetime="${this.build.created}"></time-ago>
+                <relative-time datetime="${this.build.created}"></relative-time>
             </p>
             <p>
                 ${this.build.status || "undeployed"}


### PR DESCRIPTION
The `@github/time-element` library is now deprecated. Its authors recommend using `@github/relative-time-element` instead.

This commit was motivated by the fact that Runboat uses the `<time-ago>` and `time-elements@latest` library, which currently points to version 4.0.0.
In this release, the `<time-ago>` component was removed in favor of `<relative-time>`.

Alternatively, pin the `time-elements@3.6.0` instead of `latest`.

---

<img width="297" height="142" alt="Capture d’écran 2026-05-13 à 12 03 18" src="https://github.com/user-attachments/assets/329da4f7-8f3f-49fc-b351-701cb5d463a6" />
