### PR TITLE
Default module groups to admin for review convenience

### DIFF
--- a/src/runboat/kubefiles/runboat-initialize.sh
+++ b/src/runboat/kubefiles/runboat-initialize.sh
@@ -31,9 +31,32 @@ unbuffer $(which odoo || which openerp-server) \
 
 # Try to install all addons, but do not fail in case of error, to let the build start
 # so users can work with the 'baseonly' database.
-unbuffer $(which odoo || which openerp-server) \
+if unbuffer $(which odoo || which openerp-server) \
   --data-dir=/mnt/data/odoo-data-dir \
   --db-template=template1 \
   -d ${PGDATABASE} \
   -i ${ADDONS:-base} \
-  --stop-after-init || dropdb --if-exists ${PGDATABASE} && exit 0
+  --stop-after-init ; then
+  # Grant admin all groups (except the exclusive portal/public user types) so
+  # addon menus are visible to reviewers; best effort, never fails the build.
+  $(which odoo || which openerp-server) shell \
+    --data-dir=/mnt/data/odoo-data-dir \
+    -d ${PGDATABASE} \
+    --no-http <<'PYEOF' || true
+Groups = env["res.groups"]
+admin = env.ref("base.user_admin", raise_if_not_found=False) or env.ref("base.user_root")
+field = "group_ids" if "group_ids" in admin._fields else "groups_id"
+bad = Groups.browse()
+for xid in ("base.group_portal", "base.group_public"):
+    g = env.ref(xid, raise_if_not_found=False)
+    if g:
+        bad |= g
+closure = next((f for f in ("all_implied_ids", "trans_implied_ids") if f in Groups._fields), "implied_ids")
+groups = (Groups.search([("share", "=", False)]) - bad).filtered(lambda g: not (g[closure] & bad))
+admin.write({field: [(4, g.id) for g in groups]})
+env.cr.commit()
+PYEOF
+else
+  dropdb --if-exists ${PGDATABASE}
+fi
+exit 0


### PR DESCRIPTION
Installing addons with `odoo -i` assigns nobody to the security groups they declare, so group-gated menus are invisible even to admin — every build review starts with a manual group grant in Settings → Users.

This grants admin all groups after a successful addons install, except the exclusive portal/public user types (and anything implying them) — the disjoint set `res.users._check_disjoint_groups` enforces. Filtering on `share` is not enough on Odoo 19, where portal/public are no longer share groups. Best effort (`|| true`), success path only, version-aware (`group_ids`/`groups_id`, `all_implied_ids`/`trans_implied_ids`).

Same reviewer-experience spirit as the Odoo 19 demo-data fix (#138). Verified on a self-hosted runboat: a fresh Odoo 19 build of an OCA addon with its own groups comes up with its menu visible to admin, portal/public excluded, init log clean.

AI-assisted (Claude Code); every change reviewed, tested, and owned by the author.
